### PR TITLE
Move away from alpine base images

### DIFF
--- a/.build/amd64.Dockerfile
+++ b/.build/amd64.Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch-slim
 WORKDIR /tmp
 
 #Install requirments
-RUN apt update && apt install -y python3 python3-setuptools openssl unzip curl nmap psmisc iproute2 && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y python3 python3-setuptools python3-pip openssl unzip curl nmap psmisc iproute2 && rm -rf /var/lib/apt/lists/*
 
 ## Install Python requirements.txt
 COPY requirements.txt .

--- a/.build/amd64.Dockerfile
+++ b/.build/amd64.Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.6.6-alpine3.8
+FROM debian:stretch-slim
 WORKDIR /tmp
 
 #Install requirments
-RUN apk update && apk add bash openssl unzip curl nmap psmisc iproute2 && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y python3 python3-setuptools openssl unzip curl nmap psmisc iproute2 && rm -rf /var/lib/apt/lists/*
 
 ## Install Python requirements.txt
 COPY requirements.txt .

--- a/.build/amd64.Dockerfile
+++ b/.build/amd64.Dockerfile
@@ -9,9 +9,9 @@ COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 
 ## Install diyHue
-COPY ./BridgeEmulator/web-ui/ /opt/hue-emulator/
-COPY ./BridgeEmulator/functions/ /opt/hue-emulator/
-COPY ./BridgeEmulator/protocols/ /opt/hue-emulator/
+COPY ./BridgeEmulator/web-ui/ /opt/hue-emulator/web-ui/
+COPY ./BridgeEmulator/functions/ /opt/hue-emulator/functions/
+COPY ./BridgeEmulator/protocols/ /opt/hue-emulator/protocols/
 COPY ./BridgeEmulator/HueEmulator3.py /opt/hue-emulator/
 COPY ./BridgeEmulator/config.json /opt/hue-emulator/
 

--- a/.build/amd64.Dockerfile
+++ b/.build/amd64.Dockerfile
@@ -9,7 +9,11 @@ COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 
 ## Install diyHue
-COPY ./BridgeEmulator/ /opt/hue-emulator/
+COPY ./BridgeEmulator/web-ui/ /opt/hue-emulator/
+COPY ./BridgeEmulator/functions/ /opt/hue-emulator/
+COPY ./BridgeEmulator/protocols/ /opt/hue-emulator/
+COPY ./BridgeEmulator/HueEmulator3.py /opt/hue-emulator/
+COPY ./BridgeEmulator/config.json /opt/hue-emulator/
 
 #x86_64 specific
 COPY ./BridgeEmulator/entertainment-x86_64 /opt/hue-emulator/entertainment-srv

--- a/.build/armhf.Dockerfile
+++ b/.build/armhf.Dockerfile
@@ -9,7 +9,11 @@ COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 
 ## Install diyHue
-COPY ./BridgeEmulator/ /opt/hue-emulator/
+COPY ./BridgeEmulator/web-ui/ /opt/hue-emulator/
+COPY ./BridgeEmulator/functions/ /opt/hue-emulator/
+COPY ./BridgeEmulator/protocols/ /opt/hue-emulator/
+COPY ./BridgeEmulator/HueEmulator3.py /opt/hue-emulator/
+COPY ./BridgeEmulator/config.json /opt/hue-emulator/
 
 #armhf specific
 COPY ./BridgeEmulator/entertainment-arm /opt/hue-emulator/entertainment-srv

--- a/.build/armhf.Dockerfile
+++ b/.build/armhf.Dockerfile
@@ -1,8 +1,8 @@
-FROM mielune/alpine-python3-arm
+FROM resin/rpi-raspbian
 WORKDIR /tmp
 
 #Install requirments
-RUN apk update && apk add bash openssl unzip curl nmap psmisc iproute2 && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y python3 python3-setuptools openssl unzip curl nmap psmisc iproute2 && rm -rf /var/lib/apt/lists/*
 
 ## Install Python requirements.txt
 COPY requirements.txt .
@@ -26,4 +26,3 @@ RUN sed -i "s|docker = False|docker = True |g" /opt/hue-emulator/HueEmulator3.py
 RUN rm -rf /tmp/*
 RUN ls -la /opt/hue-emulator
 ENTRYPOINT /opt/hue-emulator/startup.sh $MAC $IP
-

--- a/.build/armhf.Dockerfile
+++ b/.build/armhf.Dockerfile
@@ -9,9 +9,9 @@ COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 
 ## Install diyHue
-COPY ./BridgeEmulator/web-ui/ /opt/hue-emulator/
-COPY ./BridgeEmulator/functions/ /opt/hue-emulator/
-COPY ./BridgeEmulator/protocols/ /opt/hue-emulator/
+COPY ./BridgeEmulator/web-ui/ /opt/hue-emulator/web-ui/
+COPY ./BridgeEmulator/functions/ /opt/hue-emulator/functions/
+COPY ./BridgeEmulator/protocols/ /opt/hue-emulator/protocols/
 COPY ./BridgeEmulator/HueEmulator3.py /opt/hue-emulator/
 COPY ./BridgeEmulator/config.json /opt/hue-emulator/
 

--- a/.build/armhf.Dockerfile
+++ b/.build/armhf.Dockerfile
@@ -2,7 +2,7 @@ FROM resin/rpi-raspbian
 WORKDIR /tmp
 
 #Install requirments
-RUN apt update && apt install -y python3 python3-setuptools openssl unzip curl nmap psmisc iproute2 && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y python3 python3-setuptools python3-pip openssl unzip curl nmap psmisc iproute2 && rm -rf /var/lib/apt/lists/*
 
 ## Install Python requirements.txt
 COPY requirements.txt .

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ script:
 
 after_success:
 # Tag and push built images
-- echo $TRAVIS_BRANCH
-- echo $TRAVIS_PULL_REQUEST
+- echo $DOCKER_USER
+- echo $DOCKER_PASS
 - >
   if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ script:
 
 after_success:
 # Tag and push built images
+- echo $TRAVIS_BRANCH
+- echo $TRAVIS_PULL_REQUEST
 - >
   if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ script:
 
 after_success:
 # Tag and push built images
-- echo $DOCKER_USER
-- echo $DOCKER_PASS
 - >
   if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"


### PR DESCRIPTION
I have replaced the alpine base images with Debian based images in order to get glibc support. I have also changed the Dockerfiles to only copy the required files from the BridgeEmulator folder. At the moment it is copying the entire contents of BridgeEmulator. This leads to 3 copies of the entertainment server for example. The arm version, the x86 version and the renamed version.

Once this is merged, we should be able to merge with [mariusmotea/diyHue](https://github.com/mariusmotea/diyHue)


[![BuildStatus](https://travis-ci.com/cheesemarathon/diyHue.svg?branch=master)]()